### PR TITLE
Bump go version for Gaia main build

### DIFF
--- a/.github/workflows/gaiad-linux-main.yml
+++ b/.github/workflows/gaiad-linux-main.yml
@@ -69,8 +69,8 @@ jobs:
           git checkout main
           export LDFLAGS="-extldflags=-static"
           export CGO_ENABLED=0
-          make build
-          cp build/gaiad ~/gaiad-linux
+          make install
+          cp /home/runner/go/bin/gaiad ~/gaiad-linux
       
       - name: Print gaia version
         run: |

--- a/.github/workflows/gaiad-linux-main.yml
+++ b/.github/workflows/gaiad-linux-main.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Clone and build Gaia
         run: |
           go version
-          export GOTOOLCHAIN=go1.21
+          export GOTOOLCHAIN=go1.21.8
           git clone https://github.com/cosmos/gaia.git
           cd gaia
           git checkout main

--- a/.github/workflows/gaiad-linux-main.yml
+++ b/.github/workflows/gaiad-linux-main.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6,8,10,12,14,16,18 * * 1-5'
-  # push:
+  push:
 
 jobs:
   collect_remote_commit:

--- a/.github/workflows/gaiad-linux-main.yml
+++ b/.github/workflows/gaiad-linux-main.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Clone and build Gaia
         run: |
           go version
+          export GOTOOLCHAIN=go1.21
           git clone https://github.com/cosmos/gaia.git
           cd gaia
           git checkout main

--- a/.github/workflows/gaiad-linux-main.yml
+++ b/.github/workflows/gaiad-linux-main.yml
@@ -70,8 +70,8 @@ jobs:
           git checkout main
           export LDFLAGS="-extldflags=-static"
           export CGO_ENABLED=0
-          make install
-          cp /home/runner/go/bin/gaiad ~/gaiad-linux
+          make builod
+          cp build/gaiad ~/gaiad-linux
       
       - name: Print gaia version
         run: |

--- a/.github/workflows/gaiad-linux-main.yml
+++ b/.github/workflows/gaiad-linux-main.yml
@@ -70,7 +70,7 @@ jobs:
           git checkout main
           export LDFLAGS="-extldflags=-static"
           export CGO_ENABLED=0
-          make builod
+          make build
           cp build/gaiad ~/gaiad-linux
       
       - name: Print gaia version

--- a/.github/workflows/gaiad-linux-main.yml
+++ b/.github/workflows/gaiad-linux-main.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Install golang
         run: |
-          wget -q https://go.dev/dl/go1.20.linux-amd64.tar.gz
-          sudo tar -C /usr/local -xzf go1.20.linux-amd64.tar.gz
+          wget -q https://go.dev/dl/go1.21.8.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.21.8.linux-amd64.tar.gz
 
       - name: Update PATH
         run: |
@@ -63,6 +63,7 @@ jobs:
 
       - name: Clone and build Gaia
         run: |
+          go version
           git clone https://github.com/cosmos/gaia.git
           cd gaia
           git checkout main


### PR DESCRIPTION
Set go to v1.21.8 and set go toolchain env var before running `make build`.